### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # stonks (UNFINISHED)
 Stock program with kivy and tensorflow and other similar libraries to predict stock prices and other things
+
+
+[![Run on Repl.it](https://repl.it/badge/github/zhpixel517/stonks)](https://repl.it/github/zhpixel517/stonks)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).